### PR TITLE
Fixed a crash when files were not there to delete

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,8 +50,8 @@ namespace :package do
     sh "rm -rf packaging/tmp"
     sh "rm -f packaging/vendor/*/*/cache/*"
     sh "rm -rf packaging/vendor/ruby/*/extensions"
-    sh "find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm"
-    sh "find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm"
+    sh "find packaging/vendor/ruby/*/gems -name '*.so' | xargs rm -f"
+    sh "find packaging/vendor/ruby/*/gems -name '*.bundle' | xargs rm -f"
   end
 end
 


### PR DESCRIPTION
The rake command was giving me errors on a fresh install of Tutorial 3. I added a check for xargs to not error out when the files were missing.

$ rake package

...
find packaging/vendor/ruby/_/gems -name '_.so' | xargs rm 
rm: missing operand
Try `rm --help' for more information.
rake aborted!
...

See also: https://github.com/phusion/traveling-ruby/pull/32
